### PR TITLE
Fix errors as a result of invalid MediaTrackConstraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,32 @@
+sudo: false
 language: node_js
 node_js:
-- 0.1
+- 0.10
+
+env:
+  matrix:
+    - BROWSER=chrome  BVER=stable
+    - BROWSER=chrome  BVER=beta
+    - BROWSER=chrome  BVER=unstable
+    - BROWSER=firefox BVER=stable
+    - BROWSER=firefox BVER=beta
+    - BROWSER=firefox BVER=nightly
+
+matrix:
+  fast_finish: true
+
+  allow_failures:
+    - env: BROWSER=chrome  BVER=unstable
+    - env: BROWSER=firefox BVER=nightly
+
+before_script:
+  - ./node_modules/travis-multirunner/setup.sh
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+after_failure:
+  - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
+
 notifications:
   email:
-  - damon.oehlman@nicta.com.au
-  irc: irc.freenode.org#rtc.io
-env:
-  global:
-  - secure: 2xWcu1oo5mYo59oJww8XHlyvr5GvC+Fkuyd77cuMmX6xOCdim2vK1vShbW3jQyAL7NHvWo9HHk7zO60LFVnBr2eobKvCFz9HXtPE8zXWOzbe1L+ZziThgj4PvECHqZ+GD8LrTFGlxiMfZzPW9oL/Lk5ZQCRDwclL50wJSWDrOsc=
-  - secure: u52EVq5innJo5W6yXzT2wmkMMrrLhFvkM4bVtwzpFX5knrfBTK2syiPdov8x0tK70a+kdQLmh9VRX7ZZfvS00+SLlcSCSG6gk4/ulHOR+A546HYfMdCXizOSKKI08hUB7SK1mmXeZRT1susq5PTo5DBZ0VBXo6HgKQqRaI5ERN4=
+  - nathan.oehlman@nicta.com.au

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ that means in the context of WebRTC.
 
 [![NPM](https://nodei.co/npm/rtc-captureconfig.png)](https://nodei.co/npm/rtc-captureconfig/)
 
-[![Build Status](https://img.shields.io/travis/rtc-io/rtc-captureconfig.svg?branch=master)](https://travis-ci.org/rtc-io/rtc-captureconfig) [![unstable](https://img.shields.io/badge/stability-unstable-yellowgreen.svg)](https://github.com/dominictarr/stability#unstable) 
+[![Build Status](https://img.shields.io/travis/rtc-io/rtc-captureconfig.svg?branch=master)](https://travis-ci.org/rtc-io/rtc-captureconfig) [![unstable](https://img.shields.io/badge/stability-unstable-yellowgreen.svg)](https://github.com/dominictarr/stability#unstable)
 [![Gitter chat](https://badges.gitter.im/rtc-io/discuss.png)](https://gitter.im/rtc-io/discuss)
 
 
@@ -48,8 +48,10 @@ utility class) that looks like the following:
 }
 ```
 
-Which in turn is converted into the following media constraints for
-a getUserMedia call:
+Which in turn is able to be converted into the appropriate browser media constraints
+for a `getUserMedia` call.
+
+For Chrome/Firefox 37 and below
 
 ```js
 {
@@ -58,8 +60,7 @@ a getUserMedia call:
     mandatory: {},
     optional: [
       { minFrameRate: 15 },
-      { maxFrameRate: 25 },
-      { frameRate: { min: 15, max: 25 } },
+      { maxFrameRate: 25 }
 
       { minWidth: 1280 },
       { maxWidth: 1280 },
@@ -72,6 +73,23 @@ a getUserMedia call:
   }
 }
 ```
+
+For Firefox 38+
+
+```js
+{
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { frameRate: { min: 15, max: 25 },
+      { width: 1280 },
+      { height: 720 }
+    ]
+  }
+}
+```
+
 
 ### Experimental: Targeted Device Capture
 
@@ -196,6 +214,10 @@ Convert the internal configuration object to a valid media constraints
 representation.  In compatible browsers a list of media sources can
 be passed through in the `opts.sources` to create contraints that will
 target a specific device when captured.
+
+It is also possible to override the autodetected constraint output type by
+passing in the desired output type in `opts.constraintType`. (`legacy` for
+Chrome style constraints, `standard` for Firefox 38+ constraints)
 
 ```js
 var media = require('rtc-media');

--- a/capabilities.js
+++ b/capabilities.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var browser = require('detect-browser');
+var compareVersions = require('compare-versions')
+
+var capabilities = module.exports = {
+	moz: typeof navigator != 'undefined' && !!navigator.mozGetUserMedia,
+	browser: browser.name,
+	browserVersion: browser.version
+};
+
+capabilities.constraintsType = (capabilities.moz && compareVersions(browser.version, '38.0.0') >= 0 ? 'standard' : 'legacy');

--- a/constraints/legacy.js
+++ b/constraints/legacy.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+  This constraints builder constructs MediaStreamConstraints in the form
+  that was originally proposed, and used in Chrome (currently), Firefox (<=37),
+  Internet Explorer (Temasys) and iOS.
+
+  It constructs constraints in the form of min{attrName}: {value}, so a fully
+  constructed constraint may look like the following:
+
+  ```
+  {
+    audio: true,
+    video: {
+      optional: [
+        { minFrameRate: 15 },
+        { maxFrameRate: 30 },
+        { minWidth: 720 },
+        { maxWidth: 1080 }
+      ]
+    }
+  }
+  ```
+
+  It will also NOT produce any combined syntax which would produce failures
+  such as
+  ```
+  {
+    frameRate: { min: 15, max: 30 }
+  }
+  ```
+ **/
+module.exports = function(attrName, data) {
+  var output = [];
+
+  if (data.min) {
+    output.push(createAttr('min', attrName, data.min));
+  }
+
+  if (data.max) {
+    output.push(createAttr('max', attrName, data.max));
+  }
+
+  if (data.min && data.max && data.min === data.max) {
+    output.push(createAttr(null, attrName, data.min));
+  }
+  return output;
+};
+
+function createAttr(prefix, attrName, value) {
+  var attr = {};
+  var key = prefix && (prefix + attrName.slice(0, 1).toUpperCase() + attrName.slice(1));
+
+  attr[key || attrName] = value;
+  return attr;
+}

--- a/constraints/standard.js
+++ b/constraints/standard.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var rangeValues = ['min', 'max', 'ideal', 'exact'];
+
+/**
+  This constraints builder constructs MediaStreamConstraints in the current
+  specification (http://w3c.github.io/mediacapture-main/getusermedia.html#mediastreamconstraints).
+
+  This is currently used by Firefox 38+, and will presumably be implemented in other agents
+  soon.
+
+  It constructs constraints according to http://w3c.github.io/mediacapture-main/getusermedia.html#idl-def-MediaTrackConstraintSet
+  Primarily, this involves numeric values being either expressed as a singular value (ie. frameRate: 15),
+  or as a range (ie. frameRate: { min: 10, max: 30, ideal: 20 } ).
+
+  A fully constructed constraint may look like the following:
+
+  ```
+  {
+    audio: true,
+    video: {
+      optional: [
+        { frameRate: { min: 15, max: 30 },
+        { width: { min: 720, max: 1080 },
+        { height: 480 }
+      ]
+    }
+  }
+  ```
+
+  Important Note: This syntax, when passed to some non-implementing agents (ie. iOS, Temasys)
+  will cause critical failures.
+
+  ```
+ **/
+module.exports = function(attrName, data) {
+  var value = {};
+  var constraints = {};
+
+  if (data.min && data.max && data.min === data.max) {
+  	value = data.min;
+  } else {
+  	rangeValues.forEach(function(prop) {
+  		if (data[prop]) value[prop] = data[prop];
+  	});
+  }
+  constraints[attrName] = value;
+  return [constraints];
+};

--- a/index.js
+++ b/index.js
@@ -391,7 +391,7 @@ prot.toConstraints = function(opts) {
   // fps
   if (cfg.fps) {
     complexConstraints('video');
-    addConstraints('video', buildConstraints('frameRate', cfg.fps));
+    addConstraints('video', buildConstraints('frameRate', cfg.fps, opts));
   }
 
   // min res specified
@@ -401,12 +401,12 @@ prot.toConstraints = function(opts) {
     addConstraints('video', buildConstraints('width', {
       min: cfg.res.min && cfg.res.min.w,
       max: cfg.res.max && cfg.res.max.w
-    }));
+    }, opts));
 
     addConstraints('video', buildConstraints('height', {
       min: cfg.res.min && cfg.res.min.h,
       max: cfg.res.max && cfg.res.max.h
-    }));
+    }, opts));
   }
 
   // input camera selection

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/rtc-io/rtc-captureconfig/issues"
   },
   "devDependencies": {
-    "async": "^1.0.0",
+    "async": "^1.4.2",
     "crel": "^2.1.5",
     "getusermedia": "^1.1.0",
     "rtc-media": "^1.5.5",
@@ -31,6 +31,8 @@
   },
   "dependencies": {
     "cog": "^1.1.0",
+    "compare-versions": "^1.1.2",
+    "detect-browser": "^1.1.1",
     "rtc-core": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "async": "^1.4.2",
     "broth": "^2.1.1",
+    "browserify": "^11.0.1",
     "crel": "^2.1.5",
     "getusermedia": "^1.1.0",
     "rtc-media": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple string definition -> WebRTC constraints",
   "main": "index.js",
   "scripts": {
-    "test": "node test/all.js && zuul -- test/all.js",
+    "test": "browserify test/all.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "stability": "unstable",
@@ -23,10 +23,13 @@
   },
   "devDependencies": {
     "async": "^1.4.2",
+    "broth": "^2.1.1",
     "crel": "^2.1.5",
     "getusermedia": "^1.1.0",
     "rtc-media": "^1.5.5",
+    "tap-spec": "^4.1.0",
     "tape": "^4.0.0",
+    "travis-multirunner": "^2.7.2",
     "zuul": "^3.0.0"
   },
   "dependencies": {

--- a/test/camera-combo-constraints-mandatory.js
+++ b/test/camera-combo-constraints-mandatory.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints-mandatory');
+var format = require('./helpers/format');
 
 test('camera min:1280x720 15fps', expect({
   audio: true,
@@ -9,13 +10,24 @@ test('camera min:1280x720 15fps', expect({
       maxFrameRate: 15,
       frameRate: 15,
       minWidth: 1280,
-      width: { min: 1280 },
       minHeight: 720,
+    },
+    optional: []
+  }
+}, format.LEGACY));
+
+
+test('camera min:1280x720 15fps', expect({
+  audio: true,
+  video: {
+    mandatory: {
+      frameRate: 15,
+      width: { min: 1280 },
       height: { min: 720 }
     },
     optional: []
   }
-}));
+}, format.STANDARD));
 
 test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
   audio: true,
@@ -23,7 +35,6 @@ test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
     mandatory: {
       minFrameRate: 15,
       maxFrameRate: 25,
-      frameRate: { min: 15, max: 25 },
       minWidth: 1280,
       maxWidth: 1280,
       width: 1280,
@@ -33,4 +44,16 @@ test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
     },
     optional: []
   }
-}));
+}, format.LEGACY));
+
+test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
+  audio: true,
+  video: {
+    mandatory: {
+      frameRate: { min: 15, max: 25 },
+      width: 1280,
+      height: 720
+    },
+    optional: []
+  }
+}, format.STANDARD));

--- a/test/camera-combo-constraints.js
+++ b/test/camera-combo-constraints.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
 test('camera min:1280x720 15fps', expect({
   audio: true,
@@ -10,12 +11,22 @@ test('camera min:1280x720 15fps', expect({
       { maxFrameRate: 15 },
       { frameRate: 15 },
       { minWidth: 1280 },
-      { width: { min: 1280 } },
       { minHeight: 720 },
+    ]
+  }
+}, format.LEGACY));
+
+test('camera min:1280x720 15fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { frameRate: 15 },
+      { width: { min: 1280 } },
       { height: { min: 720 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
   audio: true,
@@ -24,7 +35,6 @@ test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
     optional: [
       { minFrameRate: 15 },
       { maxFrameRate: 25 },
-      { frameRate: { min: 15, max: 25 } },
       { minWidth: 1280 },
       { maxWidth: 1280 },
       { width: 1280 },
@@ -33,4 +43,16 @@ test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
       { height: 720 }
     ]
   }
-}));
+}, format.LEGACY));
+
+test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { frameRate: { min: 15, max: 25 } },
+      { width: 1280 },
+      { height: 720 }
+    ]
+  }
+}, format.STANDARD));

--- a/test/camera-fps-constraints.js
+++ b/test/camera-fps-constraints.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
 test('camera 15fps', expect({
   audio: true,
@@ -12,7 +13,18 @@ test('camera 15fps', expect({
       { frameRate: 15 }
     ]
   }
-}));
+}, format.LEGACY));
+
+test('camera 15fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+
+    optional: [
+      { frameRate: 15 }
+    ]
+  }
+}, format.STANDARD));
 
 test('camera max:15fps', expect({
   audio: true,
@@ -20,21 +32,39 @@ test('camera max:15fps', expect({
     mandatory: {},
     optional: [
       { maxFrameRate: 15 },
+    ]
+  }
+}, format.LEGACY));
+
+test('camera max:15fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { frameRate: { max: 15 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('camera min:25fps', expect({
   audio: true,
   video: {
     mandatory: {},
     optional: [
-      { minFrameRate: 25 },
+      { minFrameRate: 25 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera min:25fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { frameRate: { min: 25 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('camera min:15fps max:25fps', expect({
   audio: true,
@@ -42,8 +72,17 @@ test('camera min:15fps max:25fps', expect({
     mandatory: {},
     optional: [
       { minFrameRate: 15 },
-      { maxFrameRate: 25 },
+      { maxFrameRate: 25 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera min:15fps max:25fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { frameRate: { min: 15, max: 25 } }
     ]
   }
-}));
+}, format.STANDARD));

--- a/test/camera-noaudio-constraints.js
+++ b/test/camera-noaudio-constraints.js
@@ -1,6 +1,10 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
-test('camera microphone:off', expect({ video: true, audio: false }));
-test('camera microphone:none', expect({ video: true, audio: false }));
-test('camera microphone:false', expect({ video: true, audio: false }));
+test('camera microphone:off', expect({ video: true, audio: false }, format.LEGACY));
+test('camera microphone:off', expect({ video: true, audio: false }, format.STANDARD));
+test('camera microphone:none', expect({ video: true, audio: false }, format.LEGACY));
+test('camera microphone:none', expect({ video: true, audio: false }, format.STANDARD));
+test('camera microphone:false', expect({ video: true, audio: false }, format.LEGACY));
+test('camera microphone:false', expect({ video: true, audio: false }, format.STANDARD));

--- a/test/camera-resolution-constraints.js
+++ b/test/camera-resolution-constraints.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
 test('camera min:1280x720', expect({
   audio: true,
@@ -7,12 +8,21 @@ test('camera min:1280x720', expect({
     mandatory: {},
     optional: [
       { minWidth: 1280 },
+      { minHeight: 720 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera min:1280x720', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { width: { min: 1280 } },
-      { minHeight: 720 },
       { height: { min: 720 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('camera max:1280x720', expect({
   audio: true,
@@ -20,12 +30,21 @@ test('camera max:1280x720', expect({
     mandatory: {},
     optional: [
       { maxWidth: 1280 },
+      { maxHeight: 720 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera max:1280x720', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { width: { max: 1280 } },
-      { maxHeight: 720 },
       { height: { max: 720 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('camera min:640x480 max:1280x720', expect({
   audio: true,
@@ -34,11 +53,20 @@ test('camera min:640x480 max:1280x720', expect({
     optional: [
       { minWidth: 640 },
       { maxWidth: 1280 },
-      { width: { min: 640, max: 1280 } },
 
       { minHeight: 480 },
-      { maxHeight: 720 },
+      { maxHeight: 720 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera min:640x480 max:1280x720', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { width: { min: 640, max: 1280 } },
       { height: { min: 480, max: 720 } }
     ]
   }
-}));
+}, format.STANDARD));

--- a/test/camera-targets-constraints-sourced.js
+++ b/test/camera-targets-constraints-sourced.js
@@ -1,23 +1,41 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints-sourced');
+var format = require('./helpers/format');
 
-test('camera', expect({ video: true, audio: true }));
+test('camera', expect({ video: true, audio: true }, format.LEGACY));
+test('camera', expect({ video: true, audio: true }, format.STANDARD));
 test('camera:1', expect({
   video: {
     mandatory: {},
     optional: [{ sourceId: 91 }]
   },
   audio: true
-}));
+}, format.LEGACY));
+test('camera:1', expect({
+  video: {
+    mandatory: {},
+    optional: [{ sourceId: 91 }]
+  },
+  audio: true
+}, format.STANDARD));
 
-test('microphone', expect({ video: false, audio: true }));
+test('microphone', expect({ video: false, audio: true }, format.LEGACY));
+test('microphone', expect({ video: false, audio: true }, format.STANDARD));
+
 test('microphone:1', expect({
   video: false,
   audio: {
     mandatory: {},
     optional: [{ sourceId: 81 }]
   }
-}));
+}, format.LEGACY));
+test('microphone:1', expect({
+  video: false,
+  audio: {
+    mandatory: {},
+    optional: [{ sourceId: 81 }]
+  }
+}, format.STANDARD));
 
 
 test('camera microphone:1', expect({
@@ -26,7 +44,14 @@ test('camera microphone:1', expect({
     mandatory: {},
     optional: [{ sourceId: 81 }]
   }
-}));
+}, format.LEGACY));
+test('camera microphone:1', expect({
+  video:true,
+  audio: {
+    mandatory: {},
+    optional: [{ sourceId: 81 }]
+  }
+}, format.STANDARD));
 
 test('camera:1 microphone:2', expect({
   video: {
@@ -37,4 +62,15 @@ test('camera:1 microphone:2', expect({
     mandatory: {},
     optional: [{ sourceId: 82 }]
   }
-}));
+}, format.LEGACY));
+
+test('camera:1 microphone:2', expect({
+  video: {
+    mandatory: {},
+    optional: [{ sourceId: 91 }]
+  },
+  audio: {
+    mandatory: {},
+    optional: [{ sourceId: 82 }]
+  }
+}, format.STANDARD));

--- a/test/camera-targets-constraints.js
+++ b/test/camera-targets-constraints.js
@@ -1,14 +1,21 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
 // single attribute tests
-test('camera', expect({ video: true, audio: true }));
-test('camera:1', expect({ video: true, audio: true }));
+test('camera', expect({ video: true, audio: true }, format.LEGACY));
+test('camera', expect({ video: true, audio: true }, format.STANDARD));
+test('camera:1', expect({ video: true, audio: true }, format.LEGACY));
+test('camera:1', expect({ video: true, audio: true }, format.STANDARD));
 
 
-test('microphone', expect({ video: false, audio: true }));
-test('microphone:1', expect({ video: false, audio: true }));
+test('microphone', expect({ video: false, audio: true }, format.LEGACY));
+test('microphone', expect({ video: false, audio: true }, format.STANDARD));
+test('microphone:1', expect({ video: false, audio: true }, format.LEGACY));
+test('microphone:1', expect({ video: false, audio: true }, format.STANDARD));
 
 // camera + microphone
-test('camera microphone:1', expect({ video:true, audio: true }));
-test('camera:1 microphone:2', expect({ video: true, audio: true }));
+test('camera microphone:1', expect({ video:true, audio: true }, format.LEGACY));
+test('microphone:1', expect({ video: false, audio: true }, format.STANDARD));
+test('camera:1 microphone:2', expect({ video: true, audio: true }, format.LEGACY));
+test('microphone:1', expect({ video: false, audio: true }, format.STANDARD));

--- a/test/hd.js
+++ b/test/hd.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
 test('hd', expect({
   audio: true,
@@ -7,12 +8,21 @@ test('hd', expect({
     mandatory: {},
     optional: [
       { minWidth: 1280 },
+      { minHeight: 720 }
+    ]
+  }
+}, format.LEGACY));
+
+test('hd', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { width: { min: 1280 } },
-      { minHeight: 720 },
       { height: { min: 720 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('720p', expect({
   audio: true,
@@ -20,12 +30,21 @@ test('720p', expect({
     mandatory: {},
     optional: [
       { minWidth: 1280 },
+      { minHeight: 720 }
+    ]
+  }
+}, format.LEGACY));
+
+test('720p', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { width: { min: 1280 } },
-      { minHeight: 720 },
       { height: { min: 720 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('fullhd', expect({
   audio: true,
@@ -33,12 +52,21 @@ test('fullhd', expect({
     mandatory: {},
     optional: [
       { minWidth: 1920 },
+      { minHeight: 1080 }
+    ]
+  }
+}, format.LEGACY));
+
+test('fullhd', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { width: { min: 1920 } },
-      { minHeight: 1080 },
       { height: { min: 1080 } }
     ]
   }
-}));
+}, format.STANDARD));
 
 test('1080p', expect({
   audio: true,
@@ -46,10 +74,18 @@ test('1080p', expect({
     mandatory: {},
     optional: [
       { minWidth: 1920 },
+      { minHeight: 1080 }
+    ]
+  }
+}, format.LEGACY));
+
+test('1080p', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
       { width: { min: 1920 } },
-      { minHeight: 1080 },
       { height: { min: 1080 } }
     ]
   }
-}));
-
+}, format.STANDARD));

--- a/test/helpers/expect-constraints-mandatory.js
+++ b/test/helpers/expect-constraints-mandatory.js
@@ -1,10 +1,11 @@
+var extend = require('cog/extend');
 var captureconfig = require('../../');
 
-module.exports = function(expected) {
+module.exports = function(expected, opts) {
   return function(t) {
     t.plan(1);
     t.deepEqual(
-      captureconfig(t.name).toConstraints({ useMandatory: true }),
+      captureconfig(t.name).toConstraints(extend({ useMandatory: true }, opts || {})),
       expected,
       JSON.stringify(expected)
     );

--- a/test/helpers/expect-constraints-sourced.js
+++ b/test/helpers/expect-constraints-sourced.js
@@ -1,3 +1,4 @@
+var extend = require('cog/extend');
 var captureconfig = require('../../');
 var sources = [
   { kind: 'audio', id: 80, label: '' },
@@ -9,11 +10,11 @@ var sources = [
   { kind: 'audio', id: 83, label: '' }
 ];
 
-module.exports = function(expected) {
+module.exports = function(expected, opts) {
   return function(t) {
     t.plan(1);
     t.deepEqual(
-      captureconfig(t.name).toConstraints({ sources: sources }),
+      captureconfig(t.name).toConstraints(extend({ sources: sources }, opts || {})),
       expected,
       JSON.stringify(expected)
     );

--- a/test/helpers/expect-constraints.js
+++ b/test/helpers/expect-constraints.js
@@ -1,10 +1,10 @@
 var captureconfig = require('../../');
 
-module.exports = function(expected) {
+module.exports = function(expected, opts) {
   return function(t) {
     t.plan(1);
     t.deepEqual(
-      captureconfig(t.name).toConstraints(),
+      captureconfig(t.name).toConstraints(opts),
       expected,
       JSON.stringify(expected)
     );

--- a/test/helpers/format.js
+++ b/test/helpers/format.js
@@ -1,0 +1,2 @@
+exports.LEGACY = { constraintsType: 'legacy' };
+exports.STANDARD = { constraintsType: 'standard' };

--- a/test/share-constraints.js
+++ b/test/share-constraints.js
@@ -2,6 +2,7 @@ var detect = require('rtc-core/detect');
 var extend = require('cog/extend');
 var test = require('tape');
 var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
 
 function mozMediaSource(type) {
   return {
@@ -18,12 +19,23 @@ test('share', expect({
     },
     optional: [
       { maxWidth: 1920 },
+      { maxHeight: 1080 }
+    ]
+  })
+}, format.LEGACY));
+
+test('share', expect({
+  audio: false,
+  video: extend(detect.moz ? mozMediaSource('window') : {}, {
+    mandatory: detect.moz ? {} : {
+      chromeMediaSource: 'screen'
+    },
+    optional: [
       { width: { max: 1920 } },
-      { maxHeight: 1080 },
       { height: { max: 1080 } }
     ]
   })
-}));
+}, format.STANDARD));
 
 test('share:window', expect({
   audio: false,
@@ -33,9 +45,20 @@ test('share:window', expect({
     },
     optional: [
       { maxWidth: 1920 },
+      { maxHeight: 1080 }
+    ]
+  })
+}, format.LEGACY));
+
+test('share:window', expect({
+  audio: false,
+  video: extend(detect.moz ? mozMediaSource('window') : {}, {
+    mandatory: detect.moz ? {} : {
+      chromeMediaSource: 'screen'
+    },
+    optional: [
       { width: { max: 1920 } },
-      { maxHeight: 1080 },
       { height: { max: 1080 } }
     ]
   })
-}));
+}, format.STANDARD));


### PR DESCRIPTION
This fixes the issues that are occurring in iOS, and in IE (using the Temasys plugin) relating to invalid constraints being generated.

It provides support for both the currently used MediaTrackConstraints specifications, without returning a polluted constraints object that can cause issues. 

- The legacy specification as currently used by Chrome/Temasys/iOS/Firefox 37 and below (`legacy` specification in the code)

``` { minFrameRate: 10, maxFrameRate: 20 } ```

- The proposed new specification (http://w3c.github.io/mediacapture-main/#media-track-constraints), as currently used by Firefox 38 (`standard` specification in the code)

``` { frameRate: { min: 10, max: 20 } } ```