### PR TITLE
Updates to support Chrome 53 requirements

### DIFF
--- a/buildConstraints.js
+++ b/buildConstraints.js
@@ -11,13 +11,12 @@ var builders = {
 };
 
 /**
-  Constructs the appropriate constraints object, depending on the type of required
-  constraints (ie. whether it adheres to the new constraints spec (Firefox 38+), the legacy
-  constraints (Chrome, Firefox 37 and lower), or something else (ie. Opera, IE, iOS)
+  Returns a constraints builder for the appropriate version of the getUserMedia constraints
+  that are required
  **/
-module.exports = function(attrName, data, opts) {
+module.exports = function(cfg, opts) {
   var constraintsType = (opts || {}).constraintsType || capabilities.constraintsType || 'legacy';
   var builder = builders[constraintsType];
   if (!builder) throw new Error('Unsupported constraints builder');
-  return builder(attrName, data);
+  return builder(cfg, opts);
 };

--- a/capabilities.js
+++ b/capabilities.js
@@ -9,4 +9,15 @@ var capabilities = module.exports = {
 	browserVersion: browser.version
 };
 
-capabilities.constraintsType = (capabilities.moz && compareVersions(browser.version, '38.0.0') >= 0 ? 'standard' : 'legacy');
+// Mozilla constraings handling
+if (capabilities.moz) {
+	capabilities.constraintsType = (compareVersions(browser.version, '38.0.0') >= 0 ? 'standard' : 'legacy');
+}
+// Chrome constraints handling
+else if (browser.name === 'chrome') {
+	capabilities.constraintsType = (compareVersions(browser.version, '53.0.0') >= 0 ? 'standard' : 'legacy');
+}
+// Default constraints handling
+else {
+	capabilities.constraintsType = 'legacy';
+}

--- a/constraints/legacy.js
+++ b/constraints/legacy.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var detect = require('rtc-core/detect');
+var extend = require('cog/extend');
+
 /**
   This constraints builder constructs MediaStreamConstraints in the form
   that was originally proposed, and used in Chrome (currently), Firefox (<=37),
@@ -30,7 +33,123 @@
   }
   ```
  **/
-module.exports = function(attrName, data) {
+module.exports = function(cfg, opts) {
+  // Setup the config
+  cfg = cfg || {};
+
+  // Setup the default constraints
+  var constraints = {
+    audio: cfg.microphone === true ||
+      (typeof cfg.microphone == 'number' && cfg.microphone >= 0),
+
+    video: cfg.camera === true || cfg.share ||
+      (typeof cfg.camera == 'number' && cfg.camera >= 0)
+  };
+
+  // mandatory constraints
+  var m = {
+    video: {},
+    audio: {}
+  };
+
+  // optional constraints
+  var o = {
+    video: [],
+    audio: []
+  };
+
+  var sources = (opts || {}).sources || [];
+  var cameras = sources.filter(function(info) {
+    return info && info.kind === 'video';
+  });
+  var microphones = sources.filter(function(info) {
+    return info && info.kind === 'audio';
+  });
+  var selectedSource;
+  var useMandatory = !!(opts || {}).useMandatory;
+
+  function addConstraints(section, constraints) {
+    if (useMandatory) {
+      return extend.apply(null, [m[section]].concat(constraints));
+    }
+
+    o[section] = o[section].concat(constraints);
+  }
+
+  function complexConstraints(target) {
+    if (constraints[target] && typeof constraints[target] != 'object') {
+      constraints[target] = {
+        mandatory: m[target],
+        optional: o[target]
+      };
+    }
+  }
+
+  // if we have screen constraints, make magic happen
+  if (typeof cfg.share != 'undefined') {
+    complexConstraints('video');
+    if (detect.moz) {
+      constraints.video.mozMediaSource = constraints.video.mediaSource = 'window';
+    }
+    else {
+      m.video.chromeMediaSource = 'screen';
+    }
+  }
+
+  // fps
+  if (cfg.fps) {
+    complexConstraints('video');
+    addConstraints('video', buildConstraints('frameRate', cfg.fps, opts));
+  }
+
+  // min res specified
+  if (cfg.res) {
+    complexConstraints('video');
+
+    addConstraints('video', buildConstraints('width', {
+      min: cfg.res.min && cfg.res.min.w,
+      max: cfg.res.max && cfg.res.max.w
+    }, opts));
+
+    addConstraints('video', buildConstraints('height', {
+      min: cfg.res.min && cfg.res.min.h,
+      max: cfg.res.max && cfg.res.max.h
+    }, opts));
+  }
+
+  // input camera selection
+  if (typeof cfg.camera == 'number' && cameras.length) {
+    selectedSource = cameras[cfg.camera];
+
+    if (selectedSource) {
+      complexConstraints('video');
+      addConstraints('video', { sourceId: selectedSource.id });
+    }
+  }
+
+  // input microphone selection
+  if (typeof cfg.microphone == 'number' && microphones.length) {
+    selectedSource = microphones[cfg.microphone];
+
+    if (selectedSource) {
+      complexConstraints('audio');
+      addConstraints('audio', { sourceId: selectedSource.id });
+    }
+  }
+
+  ['video', 'audio'].forEach(function(target) {
+    if (constraints[target] && constraints[target].optional) {
+      constraints[target].optional = o[target];
+    }
+  });
+
+  return constraints;
+};
+
+/**
+  Builds an attribute constraint in the legacy format
+ **/
+function buildConstraints(attrName, data) {
   var output = [];
 
   if (data.min) {
@@ -47,6 +166,9 @@ module.exports = function(attrName, data) {
   return output;
 };
 
+/**
+  Creates the attribute with the given value
+ **/
 function createAttr(prefix, attrName, value) {
   var attr = {};
   var key = prefix && (prefix + attrName.slice(0, 1).toUpperCase() + attrName.slice(1));

--- a/constraints/standard.js
+++ b/constraints/standard.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var detect = require('rtc-core/detect');
 var rangeValues = ['min', 'max', 'ideal', 'exact'];
 
 /**
@@ -13,17 +14,20 @@ var rangeValues = ['min', 'max', 'ideal', 'exact'];
   Primarily, this involves numeric values being either expressed as a singular value (ie. frameRate: 15),
   or as a range (ie. frameRate: { min: 10, max: 30, ideal: 20 } ).
 
+  It should also be noted that optional and mandatory constraints do not exist, rather have been replaced
+  by the use of `exact`, `min`, `max`, and `ideal`, or the provision of a default preferred value.
+
   A fully constructed constraint may look like the following:
 
   ```
   {
     audio: true,
     video: {
-      optional: [
-        { frameRate: { min: 15, max: 30 },
-        { width: { min: 720, max: 1080 },
-        { height: 480 }
-      ]
+      // Require a min of 15, max of 30
+      frameRate: { min: 15, max: 30 },
+      width: { min: 720, max: 1080 },
+      // Prefer a height of 480
+      height: 480
     }
   }
   ```
@@ -33,11 +37,100 @@ var rangeValues = ['min', 'max', 'ideal', 'exact'];
 
   ```
  **/
-module.exports = function(attrName, data) {
+module.exports = function(cfg, opts) {
+  // Setup the config
+  cfg = cfg || {};
+
+  // Setup the default constraints
+  var constraints = {
+    audio: cfg.microphone === true ||
+      (typeof cfg.microphone == 'number' && cfg.microphone >= 0),
+
+    video: cfg.camera === true || cfg.share ||
+      (typeof cfg.camera == 'number' && cfg.camera >= 0)
+  };
+
+  var media = {
+    video: {},
+    audio: {}
+  };
+
+  var sources = (opts || {}).sources || [];
+  var cameras = sources.filter(function(info) {
+    return info && info.kind === 'video';
+  });
+  var microphones = sources.filter(function(info) {
+    return info && info.kind === 'audio';
+  });
+  var selectedSource;
+
+  function addConstraints(mediaType, updatedConstraints) {
+    if (!updatedConstraints) return;
+    Object.keys(updatedConstraints).forEach(function(constraint) {
+      if (!updatedConstraints[constraint]) return;
+      media[mediaType][constraint] = updatedConstraints[constraint];
+    });
+  }
+
+  // if we have screen constraints, make magic happen
+  if (typeof cfg.share != 'undefined') {
+    if (detect.moz) {
+      media.video.mozMediaSource = media.video.mediaSource = 'window';
+    } else {
+      media.video.chromeMediaSource = 'screen';
+    }
+  }
+
+  // fps
+  if (cfg.fps) {
+    addConstraints('video', buildConstraints('frameRate', cfg.fps, opts));
+  }
+
+  // min res specified
+  if (cfg.res) {
+    addConstraints('video', buildConstraints('width', {
+      min: cfg.res.min && cfg.res.min.w,
+      max: cfg.res.max && cfg.res.max.w
+    }, opts));
+
+    addConstraints('video', buildConstraints('height', {
+      min: cfg.res.min && cfg.res.min.h,
+      max: cfg.res.max && cfg.res.max.h
+    }, opts));
+  }
+
+  // input camera selection
+  if (typeof cfg.camera == 'number' && cameras.length) {
+    selectedSource = cameras[cfg.camera];
+
+    if (selectedSource) {
+      addConstraints('video', { deviceId: { exact: selectedSource.id } });
+    }
+  }
+
+  // input microphone selection
+  if (typeof cfg.microphone == 'number' && microphones.length) {
+    selectedSource = microphones[cfg.microphone];
+
+    if (selectedSource) {
+      addConstraints('audio', { deviceId: { exact: selectedSource.id } });
+    }
+  }
+
+  ['video', 'audio'].forEach(function(target) {
+    if (constraints[target] && Object.keys(media[target]).length > 0) {
+      constraints[target] = media[target];
+    }
+  });
+
+  return constraints;
+};
+
+function buildConstraints(attrName, data) {
   var value = {};
   var constraints = {};
-
-  if (data.min && data.max && data.min === data.max) {
+  if (typeof data.min === 'number' && typeof data.max === 'number' && data.min === data.max) {
+    if (data.min === 0) return;
   	value = data.min;
   } else {
   	rangeValues.forEach(function(prop) {
@@ -45,5 +138,5 @@ module.exports = function(attrName, data) {
   	});
   }
   constraints[attrName] = value;
-  return [constraints];
+  return constraints;
 };

--- a/package.json
+++ b/package.json
@@ -23,14 +23,14 @@
   },
   "devDependencies": {
     "async": "^1.4.2",
-    "broth": "^2.1.1",
-    "browserify": "^11.0.1",
+    "broth": "^2.2.0",
+    "browserify": "^13.0.0",
     "crel": "^2.1.5",
     "getusermedia": "^1.1.0",
     "rtc-media": "^1.5.5",
     "tap-spec": "^4.1.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^2.7.2",
+    "travis-multirunner": "^3.0.0",
     "zuul": "^3.0.0"
   },
   "dependencies": {

--- a/test/camera-combo-constraints-mandatory.js
+++ b/test/camera-combo-constraints-mandatory.js
@@ -20,12 +20,9 @@ test('camera min:1280x720 15fps', expect({
 test('camera min:1280x720 15fps', expect({
   audio: true,
   video: {
-    mandatory: {
-      frameRate: 15,
-      width: { min: 1280 },
-      height: { min: 720 }
-    },
-    optional: []
+    frameRate: 15,
+    width: { min: 1280 },
+    height: { min: 720 }
   }
 }, format.STANDARD));
 
@@ -49,11 +46,8 @@ test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
 test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
   audio: true,
   video: {
-    mandatory: {
-      frameRate: { min: 15, max: 25 },
-      width: 1280,
-      height: 720
-    },
-    optional: []
+    frameRate: { min: 15, max: 25 },
+    width: 1280,
+    height: 720
   }
 }, format.STANDARD));

--- a/test/camera-combo-constraints.js
+++ b/test/camera-combo-constraints.js
@@ -19,12 +19,9 @@ test('camera min:1280x720 15fps', expect({
 test('camera min:1280x720 15fps', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { frameRate: 15 },
-      { width: { min: 1280 } },
-      { height: { min: 720 } }
-    ]
+    frameRate: 15,
+    width: { min: 1280 },
+    height: { min: 720 }
   }
 }, format.STANDARD));
 
@@ -48,11 +45,8 @@ test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
 test('camera min:1280x720 max:1280x720 min:15fps max:25fps', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { frameRate: { min: 15, max: 25 } },
-      { width: 1280 },
-      { height: 720 }
-    ]
+    frameRate: { min: 15, max: 25 },
+    width: 1280,
+    height: 720
   }
 }, format.STANDARD));

--- a/test/camera-fps-constraints.js
+++ b/test/camera-fps-constraints.js
@@ -18,11 +18,7 @@ test('camera 15fps', expect({
 test('camera 15fps', expect({
   audio: true,
   video: {
-    mandatory: {},
-
-    optional: [
-      { frameRate: 15 }
-    ]
+    frameRate: 15
   }
 }, format.STANDARD));
 
@@ -39,10 +35,7 @@ test('camera max:15fps', expect({
 test('camera max:15fps', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { frameRate: { max: 15 } }
-    ]
+    frameRate: { max: 15 }
   }
 }, format.STANDARD));
 
@@ -59,10 +52,7 @@ test('camera min:25fps', expect({
 test('camera min:25fps', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { frameRate: { min: 25 } }
-    ]
+    frameRate: { min: 25 }
   }
 }, format.STANDARD));
 
@@ -80,9 +70,6 @@ test('camera min:15fps max:25fps', expect({
 test('camera min:15fps max:25fps', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { frameRate: { min: 15, max: 25 } }
-    ]
+    frameRate: { min: 15, max: 25 }
   }
 }, format.STANDARD));

--- a/test/camera-resolution-constraints.js
+++ b/test/camera-resolution-constraints.js
@@ -16,11 +16,8 @@ test('camera min:1280x720', expect({
 test('camera min:1280x720', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { min: 1280 } },
-      { height: { min: 720 } }
-    ]
+    width: { min: 1280 },
+    height: { min: 720 }
   }
 }, format.STANDARD));
 
@@ -38,11 +35,8 @@ test('camera max:1280x720', expect({
 test('camera max:1280x720', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { max: 1280 } },
-      { height: { max: 720 } }
-    ]
+    width: { max: 1280 },
+    height: { max: 720 }
   }
 }, format.STANDARD));
 
@@ -63,10 +57,7 @@ test('camera min:640x480 max:1280x720', expect({
 test('camera min:640x480 max:1280x720', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { min: 640, max: 1280 } },
-      { height: { min: 480, max: 720 } }
-    ]
+    width: { min: 640, max: 1280 },
+    height: { min: 480, max: 720 }
   }
 }, format.STANDARD));

--- a/test/camera-targets-constraints-sourced.js
+++ b/test/camera-targets-constraints-sourced.js
@@ -13,8 +13,7 @@ test('camera:1', expect({
 }, format.LEGACY));
 test('camera:1', expect({
   video: {
-    mandatory: {},
-    optional: [{ sourceId: 91 }]
+    deviceId: { exact: 91 }
   },
   audio: true
 }, format.STANDARD));
@@ -32,8 +31,7 @@ test('microphone:1', expect({
 test('microphone:1', expect({
   video: false,
   audio: {
-    mandatory: {},
-    optional: [{ sourceId: 81 }]
+    deviceId: { exact: 81 }
   }
 }, format.STANDARD));
 
@@ -48,8 +46,7 @@ test('camera microphone:1', expect({
 test('camera microphone:1', expect({
   video:true,
   audio: {
-    mandatory: {},
-    optional: [{ sourceId: 81 }]
+    deviceId: { exact: 81 }
   }
 }, format.STANDARD));
 
@@ -66,11 +63,9 @@ test('camera:1 microphone:2', expect({
 
 test('camera:1 microphone:2', expect({
   video: {
-    mandatory: {},
-    optional: [{ sourceId: 91 }]
+    deviceId: { exact: 91 }
   },
   audio: {
-    mandatory: {},
-    optional: [{ sourceId: 82 }]
+    deviceId: { exact: 82 }
   }
 }, format.STANDARD));

--- a/test/device-sources.js
+++ b/test/device-sources.js
@@ -1,0 +1,43 @@
+var test = require('tape');
+var expect = require('./helpers/expect-constraints');
+var format = require('./helpers/format');
+
+var sources = [
+	{deviceId: "default", kind: "audioinput", label: "Default", groupId: "2004946474"},
+	{deviceId: "62b678fb9a24ad6a6996550510cf3d31c8de040cefa64306928ba24678d29de7", kind: "audioinput", label: "Built-in Microphone", groupId: "3235599890"},
+	{deviceId: "a606cb3733d78040518504e7ab4db7b8d055fdc5248b22b1a31c3fb994ddaf2c",kind: "audioinput", label:"Display Audio", groupId: "1631477159"},
+	{deviceId: "e41cc50bffcbdcb2657da1be1d2737055822f3bc63a8710d79bb6c0de20bd9d4",kind: "videoinput", label:"FaceTime HD Camera", groupId: ""},
+	{deviceId: "67adbcba77241a069823633f0dfbf3b2ecc2d0bf5d499acf645e925f86c924ec",kind: "videoinput", label:"FaceTime HD Camera (Display) (05ac:1112)", groupId: ""},
+	{deviceId: "default", kind: "audiooutput", label: "Default", groupId: "2004946474"},
+	{deviceId: "40bf5c6a5024d15c434d3a0e60219151ce7e604abc15a58ecb8a26552bd99109",kind: "audiooutput", label:"AirPlay", groupId: "1000399423"},
+	{deviceId: "8268ccad673144d9b6ab46065d21251be8287fe31e88f2e348f0d1dd5ca489d1",kind: "audiooutput", label:"Built-in Output", groupId: "4189744161"},
+	{deviceId: "a606cb3733d78040518504e7ab4db7b8d055fdc5248b22b1a31c3fb994ddaf2c",kind: "audiooutput", label:"Display Audio", groupId: "1631477159"}
+];
+
+// single attribute tests
+test('camera', expect({ video: true, audio: true }, format.LEGACY));
+test('camera', expect({ video: true, audio: true }, format.STANDARD));
+test('camera:1', expect({ video: true, audio: true }, format.LEGACY));
+test('camera:1', expect({ video: true, audio: true }, format.STANDARD));
+
+test('camera:e41cc50bffcbdcb2657da1be1d2737055822f3bc63a8710d79bb6c0de20bd9d4', expect({
+	video: { deviceId: 'e41cc50bffcbdcb2657da1be1d2737055822f3bc63a8710d79bb6c0de20bd9d4' },
+	audio: true
+}), format.LEGACY);
+
+test('camera:e41cc50bffcbdcb2657da1be1d2737055822f3bc63a8710d79bb6c0de20bd9d4', expect({
+	video: { deviceId: { exact: 'e41cc50bffcbdcb2657da1be1d2737055822f3bc63a8710d79bb6c0de20bd9d4' } },
+	audio: true
+}), format.STANDARD);
+
+
+test('microphone', expect({ video: false, audio: true }, format.LEGACY));
+test('microphone', expect({ video: false, audio: true }, format.STANDARD));
+test('microphone:1', expect({ video: false, audio: true }, format.LEGACY));
+test('microphone:1', expect({ video: false, audio: true }, format.STANDARD));
+
+// camera + microphone
+test('camera microphone:1', expect({ video:true, audio: true }, format.LEGACY));
+test('microphone:1', expect({ video: false, audio: true }, format.STANDARD));
+test('camera:1 microphone:2', expect({ video: true, audio: true }, format.LEGACY));
+test('microphone:1', expect({ video: false, audio: true }, format.STANDARD));

--- a/test/hd.js
+++ b/test/hd.js
@@ -16,11 +16,8 @@ test('hd', expect({
 test('hd', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { min: 1280 } },
-      { height: { min: 720 } }
-    ]
+    width: { min: 1280 },
+    height: { min: 720 }
   }
 }, format.STANDARD));
 
@@ -38,11 +35,8 @@ test('720p', expect({
 test('720p', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { min: 1280 } },
-      { height: { min: 720 } }
-    ]
+    width: { min: 1280 },
+    height: { min: 720 }
   }
 }, format.STANDARD));
 
@@ -60,11 +54,8 @@ test('fullhd', expect({
 test('fullhd', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { min: 1920 } },
-      { height: { min: 1080 } }
-    ]
+    width: { min: 1920 },
+    height: { min: 1080 }
   }
 }, format.STANDARD));
 
@@ -82,10 +73,7 @@ test('1080p', expect({
 test('1080p', expect({
   audio: true,
   video: {
-    mandatory: {},
-    optional: [
-      { width: { min: 1920 } },
-      { height: { min: 1080 } }
-    ]
+    width: { min: 1920 },
+    height: { min: 1080 }
   }
 }, format.STANDARD));

--- a/test/share-constraints.js
+++ b/test/share-constraints.js
@@ -26,15 +26,16 @@ test('share', expect({
 
 test('share', expect({
   audio: false,
-  video: extend(detect.moz ? mozMediaSource('window') : {}, {
-    mandatory: detect.moz ? {} : {
-      chromeMediaSource: 'screen'
-    },
-    optional: [
-      { width: { max: 1920 } },
-      { height: { max: 1080 } }
-    ]
-  })
+  video: extend(detect.moz ? mozMediaSource('window') : {},
+    detect.moz ? {
+      width: { max: 1920 },
+      height: { max: 1080 }
+    } : {
+      chromeMediaSource: 'screen',
+      width: { max: 1920 },
+      height: { max: 1080 }
+    }
+  )
 }, format.STANDARD));
 
 test('share:window', expect({
@@ -52,13 +53,14 @@ test('share:window', expect({
 
 test('share:window', expect({
   audio: false,
-  video: extend(detect.moz ? mozMediaSource('window') : {}, {
-    mandatory: detect.moz ? {} : {
-      chromeMediaSource: 'screen'
-    },
-    optional: [
-      { width: { max: 1920 } },
-      { height: { max: 1080 } }
-    ]
-  })
+  video: extend(detect.moz ? mozMediaSource('window') : {},
+    detect.moz ? {
+      width: { max: 1920 },
+      height: { max: 1080 }
+    } : {
+      chromeMediaSource: 'screen',
+      width: { max: 1920 },
+      height: { max: 1080 }
+    }
+  )
 }, format.STANDARD));


### PR DESCRIPTION
In Chrome 53, support for the standardised form of media constraints was implemented.

Unlike Firefox's implementation, Chrome 53+ enforces a strict policy of not allowing mixed constraint formats - the standard format does away with the mandatory/optional attributes completely, resulting in the half/half approach of `rtc-captureconfig` to fail.

This moves the entirety of the `buildConstraints` implementation to the constraint implementations, allowing a much greater degree of control over how the individual implementations should handle the building of an appropriate media constraint object for the browser that is requesting the constraints.

It also updates the standard constraint implementation to be compatible with Chrome 53+, as well as the previously supported versions of Firefox.

Chrome 52 and below continue to be supported with the legacy implementation.