### PR TITLE
Add support for ideal and exact constraints on resolution and FPS

### DIFF
--- a/constraints/legacy.js
+++ b/constraints/legacy.js
@@ -108,12 +108,16 @@ module.exports = function(cfg, opts) {
 
     addConstraints('video', buildConstraints('width', {
       min: cfg.res.min && cfg.res.min.w,
-      max: cfg.res.max && cfg.res.max.w
+      max: cfg.res.max && cfg.res.max.w,
+      ideal: cfg.res.ideal && cfg.res.ideal.w,
+      exact: cfg.res.exact && cfg.res.exact.w,
     }, opts));
 
     addConstraints('video', buildConstraints('height', {
       min: cfg.res.min && cfg.res.min.h,
-      max: cfg.res.max && cfg.res.max.h
+      max: cfg.res.max && cfg.res.max.h,
+      ideal: cfg.res.ideal && cfg.res.ideal.h,
+      exact: cfg.res.exact && cfg.res.exact.h,
     }, opts));
   }
 
@@ -151,6 +155,14 @@ module.exports = function(cfg, opts) {
  **/
 function buildConstraints(attrName, data) {
   var output = [];
+
+  if (data.ideal && !data.max) {
+    data.max = data.ideal;
+  }
+
+  if (data.exact) {
+    data.min = data.max = data.exact;
+  }
 
   if (data.min) {
     output.push(createAttr('min', attrName, data.min));

--- a/constraints/standard.js
+++ b/constraints/standard.js
@@ -90,12 +90,16 @@ module.exports = function(cfg, opts) {
   if (cfg.res) {
     addConstraints('video', buildConstraints('width', {
       min: cfg.res.min && cfg.res.min.w,
-      max: cfg.res.max && cfg.res.max.w
+      max: cfg.res.max && cfg.res.max.w,
+      ideal: cfg.res.ideal && cfg.res.ideal.w,
+      exact: cfg.res.exact && cfg.res.exact.w,
     }, opts));
 
     addConstraints('video', buildConstraints('height', {
       min: cfg.res.min && cfg.res.min.h,
-      max: cfg.res.max && cfg.res.max.h
+      max: cfg.res.max && cfg.res.max.h,
+      ideal: cfg.res.ideal && cfg.res.ideal.h,
+      exact: cfg.res.exact && cfg.res.exact.h,
     }, opts));
   }
 

--- a/index.js
+++ b/index.js
@@ -204,18 +204,16 @@ prot.screen = function() {
 };
 
 /**
-  #### max(data)
+ #### _apply(prop, data)
 
-  Update a maximum constraint.  If an fps constraint this will be directed
-  to the `maxfps` modifier.
-
+ Parses and applies the resolution or fps from data to prop
 **/
-prot.max = function(data) {
+prot._apply = function(prop, data) {
   var res;
 
   // if this is an fps specification parse
   if (data.slice(-3).toLowerCase() == 'fps') {
-    return this.maxfps(data);
+    return this[prop + 'fps'](data);
   }
 
   // parse the resolution
@@ -223,7 +221,18 @@ prot.max = function(data) {
 
   // initialise the fps config stuff
   this.cfg.res = this.cfg.res || {};
-  this.cfg.res.max = res;
+  this.cfg.res[prop] = res;
+}
+
+/**
+  #### max(data)
+
+  Update a maximum constraint.  If an fps constraint this will be directed
+  to the `maxfps` modifier.
+
+**/
+prot.max = function(data) {
+  this._apply('max', data);
 };
 
 /**
@@ -246,21 +255,7 @@ prot.maxfps = function(data) {
   or FPS.
 **/
 prot.min = function(data) {
-  var res;
-
-  // if this is an fps specification parse
-  if (data.slice(-3).toLowerCase() == 'fps') {
-    return this.minfps(data);
-  }
-
-  // parse the resolution
-  res = this._parseRes(data);
-
-  // initialise the fps config stuff
-  this.cfg.res = this.cfg.res || {};
-
-  // add the min
-  this.cfg.res.min = res;
+  this._apply('min', data);
 };
 
 /**
@@ -274,6 +269,66 @@ prot.minfps = function(data) {
 
   // set the max fps
   this.cfg.fps.min = parseFloat(data.slice(0, -3));
+};
+
+/**
+  #### ideal(data)
+
+  Updates an ideal constraint.  This can be either related to resolution
+  or FPS.
+**/
+prot.ideal = function(data) {
+  this._apply('ideal', data);
+};
+
+/**
+  #### idealfps(data)
+
+  Sets the ideal fps
+**/
+prot.idealfps = function(data) {
+  // ensure we have an fps component
+  this.cfg.fps = this.cfg.fps || {};
+
+  // set the max fps
+  this.cfg.fps.ideal = parseFloat(data.slice(0, -3));
+};
+
+/**
+  #### exact(data)
+
+  Updates an exact constraint.  This can be either related to resolution
+  or FPS.
+**/
+prot.exact = function(data) {
+  this._apply('exact', data);
+};
+
+/**
+  #### exactfps(data)
+
+  Sets the exact fps
+**/
+prot.exactfps = function(data) {
+  // ensure we have an fps component
+  this.cfg.fps = this.cfg.fps || {};
+
+  // set the max fps
+  this.cfg.fps.exact = parseFloat(data.slice(0, -3));
+};
+
+prot.hd = prot['720p'] = function() {
+  this.cfg.camera = true;
+  this.min('1280x720');
+};
+
+prot.fullhd = prot['1080p'] = function() {
+  this.cfg.camera = true;
+  this.min('1920x1080');
+};
+
+prot.fps = function(fps) {
+  this.cfg.fps = { min: fps, max: fps };
 };
 
 prot.hd = prot['720p'] = function() {

--- a/test/camera-fps-constraints.js
+++ b/test/camera-fps-constraints.js
@@ -73,3 +73,21 @@ test('camera min:15fps max:25fps', expect({
     frameRate: { min: 15, max: 25 }
   }
 }, format.STANDARD));
+
+test('camera min:15fps ideal:25fps', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { minFrameRate: 15 },
+      { maxFrameRate: 25 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera min:15fps ideal:25fps', expect({
+  audio: true,
+  video: {
+    frameRate: { min: 15, ideal: 25 }
+  }
+}, format.STANDARD));

--- a/test/camera-fps.js
+++ b/test/camera-fps.js
@@ -25,3 +25,12 @@ test('camera min:15fps max:25fps', expect({
     max: 25
   }
 }));
+
+test('camera min:10fps ideal:15fps', expect({
+  camera: true,
+  microphone: true,
+  fps: {
+    min: 10,
+    ideal: 15
+  }
+}));

--- a/test/camera-resolution-constraints.js
+++ b/test/camera-resolution-constraints.js
@@ -61,3 +61,66 @@ test('camera min:640x480 max:1280x720', expect({
     height: { min: 480, max: 720 }
   }
 }, format.STANDARD));
+
+test('camera ideal:640x480 ', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { maxWidth: 640 },
+      { maxHeight: 480 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera ideal:640x480', expect({
+  audio: true,
+  video: {
+    width: { ideal: 640 },
+    height: { ideal: 480 }
+  }
+}, format.STANDARD));
+
+test('camera ideal:640x480 min:320x240', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { minWidth: 320 },
+      { maxWidth: 640 },
+      { minHeight: 240 },
+      { maxHeight: 480 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera ideal:640x480 min:320x240', expect({
+  audio: true,
+  video: {
+    width: { ideal: 640, min: 320 },
+    height: { ideal: 480, min: 240 }
+  }
+}, format.STANDARD));
+
+test('camera exact:640x480 ', expect({
+  audio: true,
+  video: {
+    mandatory: {},
+    optional: [
+      { minWidth: 640 },
+      { maxWidth: 640 },
+      { width: 640 },
+      { minHeight: 480 },
+      { maxHeight: 480 },
+      { height: 480 }
+    ]
+  }
+}, format.LEGACY));
+
+test('camera exact:640x480', expect({
+  audio: true,
+  video: {
+    width: { exact: 640 },
+    height: { exact: 480 }
+  }
+}, format.STANDARD));

--- a/test/camera-resolution.js
+++ b/test/camera-resolution.js
@@ -25,3 +25,28 @@ test('camera min:640x480 max:1280x720', expect({
     max: { w: 1280, h: 720 }
   }
 }));
+
+test('camera ideal:640x480', expect({
+camera: true,
+  microphone: true,
+  res: {
+    ideal: { w: 640, h: 480 },
+  }
+}));
+
+test('camera ideal:640x480 min:320x240', expect({
+camera: true,
+  microphone: true,
+  res: {
+    ideal: { w: 640, h: 480 },
+    min: { w: 320, h: 240 }
+  }
+}));
+
+test('camera exact:640x480', expect({
+camera: true,
+  microphone: true,
+  res: {
+    exact: { w: 640, h: 480 },
+  }
+}));


### PR DESCRIPTION
This adds support for ideal and exact constraints to be supplied when specifying resolution and FPS requirements.

`ideal` and `exact` are provided in the same manner as `min` and `max` are.

For example:
`camera ideal:800x600` 

They can also of course be used in conjunction with other parameters, ie `camera min:320x240 ideal:800x600`

When converting to a constraints object, `ideal` and `exact` correspond the the `ideal` and `exact` properties in the updated media constraints format.

When converting to a legacy media constraints format, `ideal:WxH` is converted to `max:WxH`, whereas `exact:WxH` is converted to `min:WxH max:WxH`.