### PR TITLE
Support Safari 12 constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-- 0.10
+- 6
+- lts/*
+- stable
 
 env:
   matrix:
@@ -29,4 +31,4 @@ after_failure:
 
 notifications:
   email:
-  - nathan.oehlman@nicta.com.au
+  - nathan+rtcio@coviu.com

--- a/capabilities.js
+++ b/capabilities.js
@@ -17,6 +17,10 @@ if (capabilities.moz) {
 else if (browser.name === 'chrome') {
 	capabilities.constraintsType = (compareVersions(browser.version, '53.0.0') >= 0 ? 'standard' : 'legacy');
 }
+// Safari constraints handling
+else if (browser.name === 'safari') {
+	capabilities.constraintsType = (compareVersions(browser.version, '605.1.15') >= 0 ? 'standard' : 'legacy');
+}
 // Default constraints handling
 else {
 	capabilities.constraintsType = 'legacy';

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "rtc-media": "^1.5.5",
     "tap-spec": "^4.1.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^3.0.0",
+    "travis-multirunner": "^4.3.1",
     "zuul": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Update the capabilities detector to detect Safari, and use the standards constraints model for 12+.