### PR TITLE
Update detect-browser to 4.6.0 to support accurate Safari detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 sudo: false
+services:
+  - xvfb
 language: node_js
 node_js:
 - 6
@@ -23,8 +25,6 @@ matrix:
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true

--- a/capabilities.js
+++ b/capabilities.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var browser = require('detect-browser');
+var browser = require('detect-browser').detect();
 var compareVersions = require('compare-versions')
 
 var capabilities = module.exports = {
@@ -19,7 +19,7 @@ else if (browser.name === 'chrome') {
 }
 // Safari constraints handling
 else if (browser.name === 'safari') {
-	capabilities.constraintsType = (compareVersions(browser.version, '605.1.15') >= 0 ? 'standard' : 'legacy');
+	capabilities.constraintsType = (compareVersions(browser.version, '12.0.0') >= 0 ? 'standard' : 'legacy');
 }
 // iOS Safari constraints handling
 else if (browser.name === 'ios') {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "cog": "^1.1.0",
     "compare-versions": "^1.1.2",
-    "detect-browser": "^1.1.1",
+    "detect-browser": "^4.6.0",
     "rtc-core": "^4.0.0"
   }
 }


### PR DESCRIPTION
This updates, in keeping with the update to rtc-core, the detect-browser version to `4.6.0`.

This fixes issues with this library reporting Safari using the Webkit version instead of the browser version. Included in this is also updating the detection logic to ensure that Safari 12+ is using the standard constraints type.