### PR TITLE
Add support for crios (chrome on iOS)

### DIFF
--- a/capabilities.js
+++ b/capabilities.js
@@ -1,35 +1,54 @@
-'use strict';
+"use strict"
 
-var browser = require('detect-browser').detect();
-var compareVersions = require('compare-versions')
+const browser = require("detect-browser").detect()
+const compareVersions = require("compare-versions")
 
-var capabilities = module.exports = {
-	moz: typeof navigator != 'undefined' && !!navigator.mozGetUserMedia,
-	browser: browser.name,
-	browserVersion: browser.version
-};
+const capabilities = (module.exports = {
+  moz: typeof navigator != "undefined" && !!navigator.mozGetUserMedia,
+  browser: browser.name,
+  browserVersion: browser.version,
+})
+
+const getConstraintsType = (condition: boolean) =>
+  condition ? "standard" : "legacy"
 
 // Mozilla constraings handling
 if (capabilities.moz) {
-	capabilities.constraintsType = (compareVersions(browser.version, '38.0.0') >= 0 ? 'standard' : 'legacy');
+  capabilities.constraintsType = getConstraintsType(
+    compareVersions(browser.version, "38.0.0") >= 0
+  )
 }
 // Chrome constraints handling
-else if (browser.name === 'chrome') {
-	capabilities.constraintsType = (compareVersions(browser.version, '53.0.0') >= 0 ? 'standard' : 'legacy');
+else if (browser.name === "chrome") {
+  capabilities.constraintsType = getConstraintsType(
+    compareVersions(browser.version, "53.0.0") >= 0
+  )
+}
+// Chrome on iOS constraints handling
+else if (browser.name === "crios") {
+  capabilities.constraintsType = getConstraintsType(
+    compareVersions(browser.version, "56.0.0") >= 0
+  )
 }
 // Safari constraints handling
-else if (browser.name === 'safari') {
-	capabilities.constraintsType = (compareVersions(browser.version, '12.0.0') >= 0 ? 'standard' : 'legacy');
+else if (browser.name === "safari") {
+  capabilities.constraintsType = getConstraintsType(
+    compareVersions(browser.version, "12.0.0") >= 0
+  )
 }
 // Edge constraints handling
-else if ((/^edge.*$/).test(browser.name)) {
-	capabilities.constraintsType = (compareVersions(browser.version, '79.0.0') >= 0 ? 'standard' : 'legacy');
+else if (/^edge.*$/.test(browser.name)) {
+  capabilities.constraintsType = getConstraintsType(
+    compareVersions(browser.version, "79.0.0") >= 0
+  )
 }
 // iOS Safari constraints handling
-else if (browser.name === 'ios') {
-	capabilities.constraintsType = (compareVersions(browser.version, '11.0.0') >= 0 ? 'standard' : 'legacy');
+else if (browser.name === "ios") {
+  capabilities.constraintsType = getConstraintsType(
+    compareVersions(browser.version, "11.0.0") >= 0
+  )
 }
 // Default constraints handling
 else {
-	capabilities.constraintsType = 'legacy';
+  capabilities.constraintsType = "legacy"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtc-captureconfig",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Simple string definition -> WebRTC constraints",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The user agent string for chrome on iOS:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1Mozilla/5.0 (iPhone; CPU iPhone OS 17_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1
```